### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,10 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
+permissions:
+  contents: read
+  statuses: write
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/teamMay/factory/security/code-scanning/3](https://github.com/teamMay/factory/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function. Based on the provided workflow, the following permissions are needed:
- `contents: read` for accessing the repository contents.
- `statuses: write` for updating commit statuses (if applicable during CI).
- `security-events: write` for uploading coverage reports to Codecov.

The `permissions` block will be added after the `name` field (line 4) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
