### PR TITLE
new: ✨ Seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,3 +327,87 @@ export class TypeormUserFactory extends TypeormFactory<User> {
   };
 }
 ```
+
+---
+
+### Seeding (NEW)
+
+You can now easily seed your database using your factories with the `runSeed` utility.
+
+#### Example
+
+Create a `seed.ts` file in your project:
+
+```typescript
+import { runSeed } from '@adrien-may/factory';
+import { UserFactory } from './factories/user.factory';
+import { PostFactory } from './factories/post.factory';
+import { dataSource } from './db'; // your TypeORM DataSource
+
+export let fixtures: any = {};
+
+async function main() {
+  fixtures = await runSeed({
+    dataSource,
+    factories: { UserFactory, PostFactory },
+    seeds: async ({ UserFactory, PostFactory }) => {
+      const users = await UserFactory.createMany(10);
+      const posts = await PostFactory.createMany(20);
+      return {
+        users,
+        posts,
+      };
+    },
+  });
+}
+
+main();
+```
+
+* All factories are instantiated with the provided `dataSource`.
+* You can use all factory methods (create, createMany, etc) inside the `seeds` function.
+* This utility is framework-agnostic but works best with TypeORM.
+* You can access created instances via the `fixtures` object.
+
+---
+
+#### Example: Seeding in Jest setup
+
+You can also use `runSeed` in your Jest setup to ensure your test database is seeded before tests run:
+
+```typescript
+// jest.setup.ts
+import { runSeed } from '@adrien-may/factory';
+import { UserFactory } from './factories/user.factory';
+import { dataSource } from './db';
+
+beforeAll(async () => {
+  await runSeed({
+    dataSource,
+    factories: { UserFactory },
+    seeds: async ({ UserFactory }) => {
+      await UserFactory.createMany(5);
+    },
+  });
+});
+```
+
+---
+
+#### Example: Running seeds via npm
+
+Add this to your `package.json` scripts:
+
+```json
+"scripts": {
+  "seed": "ts-node ./seed.ts"
+}
+```
+
+Then run:
+
+```bash
+npm run seed
+```
+
+---

--- a/__tests__/seed.test.ts
+++ b/__tests__/seed.test.ts
@@ -1,0 +1,31 @@
+import { runSeed } from '../src/seed';
+
+class DummyFactory {
+  static created: any[] = [];
+  constructor() {}
+  async createMany(n: number, attrs?: any) {
+    for (let i = 0; i < n; i++) {
+      DummyFactory.created.push(attrs || {});
+    }
+    return DummyFactory.created;
+  }
+}
+
+describe('runSeed', () => {
+  beforeEach(() => {
+    DummyFactory.created = [];
+  });
+
+  it('should instantiate factories and run seeds', async () => {
+    const fakeDataSource = {};
+    await runSeed({
+      dataSource: fakeDataSource as any,
+      factories: { DummyFactory },
+      seeds: async ({ DummyFactory }) => {
+        await DummyFactory.createMany(3, { foo: 'bar' });
+      },
+    });
+    expect(DummyFactory.created).toHaveLength(3);
+    expect(DummyFactory.created[0]).toEqual({ foo: 'bar' });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './factory';
 export * from './factory-storage';
 export * from './lazy-attribute';
 export * from './lazy-sequence';
+export * from './seed';
 export * from './sequence';
 export * from './subfactory';
 export * from './types';

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -1,0 +1,33 @@
+import type { DataSource } from 'typeorm';
+
+/**
+ * SeedRunner allows you to easily seed your database using your factories.
+ *
+ * Example usage:
+ *   await runSeed({
+ *     dataSource,
+ *     seeds: async (factories) => {
+ *       await factories.UserFactory.createMany(10);
+ *       await factories.PostFactory.createMany(20);
+ *     },
+ *     factories: { UserFactory, PostFactory }
+ *   });
+ */
+export async function runSeed<TFactories extends Record<string, any>>({
+  dataSource,
+  seeds,
+  factories,
+}: {
+  dataSource: DataSource;
+  seeds: (factories: Record<keyof TFactories, InstanceType<TFactories[keyof TFactories]>>) => Promise<void>;
+  factories: TFactories;
+}) {
+  // Instantiate all factories with the provided dataSource
+  const instantiatedFactories: Record<keyof TFactories, InstanceType<TFactories[keyof TFactories]>> = {} as Record<keyof TFactories, InstanceType<TFactories[keyof TFactories]>>;
+  for (const [name, FactoryClass] of Object.entries(factories) as [keyof TFactories, TFactories[keyof TFactories]][]) {
+    instantiatedFactories[name] = new FactoryClass(dataSource);
+  }
+  return seeds(instantiatedFactories);
+}
+
+// Optionally, users can create their own seed.ts file and call runSeed()


### PR DESCRIPTION
@matthieuMay I did not try "for real" this new feature but what do you think about it ?

We could also for an approach where we discover "**.fixture.ts" files and execute them for seeding purpose instead of a single seed function. That would avoid to have a gigantic "seed" function to write and maintain.

The current structure is quite permissive and end users are free to write the function as they want.

With typeorm, I'm not really sure how we should handle the connection (and thus DataSource) in a jest.setup.ts approach. Also... If we want to guarantee a bit of relevancy, we may need to specify that "fixtures" (instances returned after seed have been applied) should NOT be modified. Altering any instances in the fixtures would be error prone.