### PR TITLE
fix: 💚 Fix build

### DIFF
--- a/__tests__/mocks/next-env.ts
+++ b/__tests__/mocks/next-env.ts
@@ -1,0 +1,18 @@
+/**
+ * Mock for @next/env used by payload's loadEnv.
+ * Payload does `import nextEnvImport from '@next/env'; const { loadEnvConfig } = nextEnvImport;`
+ * Since @next/env is CJS with __esModule but no default export, SWC interop breaks.
+ * This mock provides the expected shape.
+ */
+export const loadEnvConfig = (
+  _dir: string,
+  _dev?: boolean,
+): {
+  combinedEnv: NodeJS.ProcessEnv;
+  loadedEnvFiles: Array<{ path: string; contents: string }>;
+} => ({
+  combinedEnv: process.env,
+  loadedEnvFiles: [],
+});
+
+export default { loadEnvConfig };

--- a/__tests__/mocks/prettier.ts
+++ b/__tests__/mocks/prettier.ts
@@ -1,0 +1,36 @@
+/**
+ * Stub for prettier, which is loaded transitively via:
+ * @payloadcms/db-sqlite → @payloadcms/drizzle → payload/node → generateTypes → json-schema-to-typescript → prettier.
+ *
+ * Prettier's CJS entry uses `import("./index.mjs")` at module evaluation time,
+ * which fails in Jest's VM context without --experimental-vm-modules.
+ * Since prettier is only used for code formatting in generateTypes (not needed in tests), this stub is safe.
+ */
+
+export const format = (source: string): Promise<string> => Promise.resolve(source);
+
+export const check = (): Promise<boolean> => Promise.resolve(true);
+
+export const formatWithCursor = (source: string): Promise<{ formatted: string; cursorOffset: number }> =>
+  Promise.resolve({ formatted: source, cursorOffset: 0 });
+
+export const resolveConfig = (): Promise<null> => Promise.resolve(null);
+
+export const getFileInfo = (): Promise<{
+  ignored: boolean;
+  inferredParser: null;
+}> => Promise.resolve({ ignored: false, inferredParser: null });
+
+export const getSupportInfo = (): Promise<{
+  languages: never[];
+  options: never[];
+}> => Promise.resolve({ languages: [], options: [] });
+
+export default {
+  format,
+  check,
+  formatWithCursor,
+  resolveConfig,
+  getFileInfo,
+  getSupportInfo,
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,6 +17,10 @@ module.exports = {
       },
     ],
   },
+  moduleNameMapper: {
+    '^@next/env$': '<rootDir>/__tests__/mocks/next-env.ts',
+    '^prettier$': '<rootDir>/__tests__/mocks/prettier.ts',
+  },
   testPathIgnorePatterns: ['/node_modules/', '/build/', '/dist/'],
   coverageProvider: 'v8',
 };


### PR DESCRIPTION
Voilà le bilan de mon agent mais je suis ni convaincu ni heureux. Mais les tests passent 

Two mocks were added to [jest.config.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) via [moduleNameMapper](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to fix payload 3.76.1 compatibility with Jest + SWC:

1. [@next/env](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) mock (__tests__/mocks/next-env.ts)

Payload's loadEnv.js does import nextEnvImport from '@next/env'; const { loadEnvConfig } = nextEnvImport;. The [@next/env](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) package is CJS but sets __esModule: true without a proper default export. When SWC transforms this to CJS interop, nextEnvImport resolves to undefined, causing the [Cannot destructure property 'loadEnvConfig'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) error. The mock provides the expected default export shape.

2. prettier mock (__tests__/mocks/prettier.js)

The import chain @payloadcms/db-sqlite → [@payloadcms/drizzle](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [payload/node](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → generateTypes → json-schema-to-typescript → prettier causes prettier/index.cjs to execute import("./index.mjs") at module load time. This dynamic import fails in Jest's VM context with A dynamic import callback was invoked without --experimental-vm-modules. Since prettier is only used for code formatting in generateTypes (not exercised in tests), a no-op stub is safe.